### PR TITLE
Fixed comparison for new versions

### DIFF
--- a/D4Companion/ViewModels/MainWindowViewModel.cs
+++ b/D4Companion/ViewModels/MainWindowViewModel.cs
@@ -106,14 +106,15 @@ namespace D4Companion.ViewModels
             var release = _releaseManager?.Releases?.First();
             if (release != null)
             {
-                string currentVersion = $"v{Assembly.GetExecutingAssembly().GetName().Version}";
-                string latestVersion = release.Version;
-                if (!currentVersion.Equals(latestVersion))
+                var latest  = Version.Parse(release.Version[1..]);
+                var current = Assembly.GetExecutingAssembly().GetName().Version;
+
+                if (latest > current)
                 {
                     WindowTitle = $"Diablo IV Companion v{Assembly.GetExecutingAssembly().GetName().Version} ({release.Version} available)";
                     _eventAggregator.GetEvent<InfoOccurredEvent>().Publish(new InfoOccurredEventParams
                     {
-                        Message = $"New version available: {latestVersion}"
+                        Message = $"New version available: {release.Version}"
                     });
 
                     // Open update dialog


### PR DESCRIPTION
Right now, the updater mechanism compares only for version identity, not for the order of versions.

For example:
Using the latest commit on Github says it is version "v2.2.7.0". The last release is "v2.2.6.0". Since they are different, the app thinks there is a new version, when in reality there is none.

This fixes it by using the [Version](https://learn.microsoft.com/en-us/dotnet/api/system.version) class.